### PR TITLE
fix: #66 그래프 데이터 값 순서 변경

### DIFF
--- a/src/sagas/note.ts
+++ b/src/sagas/note.ts
@@ -27,6 +27,7 @@ const format = (newList, originData, page) => {
   const { list: oriList, graph: oriGraph } = originData;
   const list = [].concat(page > 1 ? oriList : []);
   const graph = [].concat(page > 1 ? oriGraph : []);
+  graph.reverse();
   for (const data of newList) {
     list.push(data);
     graph.push(6 - data.state);


### PR DESCRIPTION
- 리스트와 그래프에 그려지는 데이터 순서가 반대로 되어있는데 배열에 추가될때 뒤집혀서 추가됨